### PR TITLE
Add error reporting for failed platform build

### DIFF
--- a/crosscompile.bash
+++ b/crosscompile.bash
@@ -33,7 +33,10 @@ function go-crosscompile-build-all {
 	for PLATFORM in $PLATFORMS; do
 		CMD="go-crosscompile-build ${PLATFORM}"
 		echo "$CMD"
-		$CMD >/dev/null
+		$CMD || {
+                    echo "*** FAILED BUILD $PLATFORM ***"
+                    break
+                }
 	done
 }	
 


### PR DESCRIPTION
I was using your most excellent tool to test that go compiled under all platforms after patching it.

However I noticed (after submitting a request that didn't compile on Windows) that your tool doesn't report errors on builds.  I've fixed that and made the build verbose too so the user can see that something is happening and so that I can see what went wrong when I'm testing cross compiles!

Thanks
