### PR TITLE
Added a 'go-build-all' function to 'go build' for all platforms at once, into a folder structure

### DIFF
--- a/crosscompile.bash
+++ b/crosscompile.bash
@@ -42,23 +42,27 @@ function go-build-all {
       		GOOS=${PLATFORM%/*}
         	GOARCH=${PLATFORM#*/}
                 #TODO - check if basename should actually be the next non-option argv. Or warn.
-                BASENAME=${PWD##*/}
-                # if necessary, set GOBIN according to go's usual logic
-                if [ -z "$GOBIN" ]; then
-                  MYGOBIN="$GOPATH/bin"
-                else
-                  MYGOBIN="$GOBIN"
+                APPNAME=${PWD##*/}
+                # You can set OUTPUTDIR as an environment variable.
+                # Otherwise it defaults to a subfolder of $GOBIN called $APPNAME-xc
+                if [ -z "$OUTPUTDIR" ]; then
+                   # if necessary, set GOBIN according to go's usual logic
+                   if [ -z "$GOBIN" ]; then
+                     MYGOBIN="$GOPATH/bin"
+                   else
+                     MYGOBIN="$GOBIN"
+                   fi
+                   echo "$MYGOBIN"
+                   OUTPUTDIR="${MYGOBIN}/$APPNAME-xc"
                 fi
-                #echo "GOBIN=$GOBIN"
-                #MYGOBIN=${GOBIN:?"$GOPATH/bin"}
-                echo "$MYGOBIN"
-                # use a subfolder of GOBIN called xc
-                OUTPUTDIR="${MYGOBIN}/xc/$BASENAME/$PLATFORM"
+                FULLOUTPUTDIR="${OUTPUTDIR}/${GOOS}_${GOARCH}"
                 if [ "$GOOS" == "windows" ]; then
-                   BASENAME="$BASENAME.exe"
+                   EXENAME="$APPNAME.exe"
+                else
+                   EXENAME="$APPNAME"
                 fi
-                CMD="go-${GOOS}-${GOARCH} build -o ${OUTPUTDIR}/${BASENAME} $@"
-                MKDIRCMD="mkdir -p \"$OUTPUTDIR\""
+                CMD="go-${GOOS}-${GOARCH} build -o ${FULLOUTPUTDIR}/${EXENAME} $@"
+                MKDIRCMD="mkdir -p \"$FULLOUTPUTDIR\""
                 echo "Running: $MKDIRCMD"
                 mkdir -p "$OUTPUTDIR"
                 ls "$OUTPUTDIR"


### PR DESCRIPTION
Hi Dave, 

I found your script while wanting to make my compiled Go artifacts available for all platforms, via ghpages, so I started off with this addition to your script.(It was important to write a new function just to handle the -o output-file variable). I don't know how cleanly it fits into the rest of your script, but it served its purpose for me, so here it is if you want it.

I have since gone on and re-written my function in Go itself, (using os.exec) - please take a look: [goxc](http://laher.github.com/goxc/) - this also has the 'build toolchain' option, and - my favourite - generates a markdown file with relative links to the artifacts for that build. So, I've used it for 'downloads' pages on my jekyll gh-pages sites, for goxc itself and also my small but growing list of other go projects. e.g.2 [mkdo](http://laher.github.com/mkdo).

Thanks for this work and the associated blog post. Very handy. Go's cross-platform-standalone-binary-ness is one of its big draws for me. Even if you're not interested in the pull request then I hope you enjoy the goxc thing, such as it is

Cheers
Am
