### PR TITLE
Add go-build-all

### DIFF
--- a/crosscompile.bash
+++ b/crosscompile.bash
@@ -56,7 +56,8 @@ function go-build-all {
 	for PLATFORM in $PLATFORMS; do
 		GOOS=${PLATFORM%/*}
 		GOARCH=${PLATFORM#*/}
-		CMD="go-${GOOS}-${GOARCH} build -o $@-${GOOS}-${GOARCH} $@"
+		OUTPUT=`echo $@ | sed 's/\.go//'` 
+		CMD="go-${GOOS}-${GOARCH} build -o $OUTPUT-${GOOS}-${GOARCH} $@"
 		echo "$CMD"
 		$CMD
 	done


### PR DESCRIPTION
I couldn't figure out how to go this by just calling go-all, so I made this quick function to do it for me. I figured it might be useful. :)

go-build-all builds for all platforms and appends the GOOS and GOARCH to each output file.
