### PR TITLE
ZSH compat update on crosscompile.bash

### DIFF
--- a/crosscompile.bash
+++ b/crosscompile.bash
@@ -5,6 +5,7 @@
 
 # support functions for go cross compilation
 
+[ -e setopt ] && setopt shwordsplit
 PLATFORMS="darwin/386 darwin/amd64 freebsd/386 freebsd/amd64 freebsd/arm linux/386 linux/amd64 linux/arm windows/386 windows/amd64"
 
 function go-alias {


### PR DESCRIPTION
Bonjour Dave! 
Zsh doesn't split strings on blanks like bash with $IFS set to `$' \n\t'`. 
`shwordsplit` is a workaround which doesn't require to convert your long "bash-iterable" strings to arrays
