### PR TITLE
Quote parameters to go

### DIFF
--- a/crosscompile.bash
+++ b/crosscompile.bash
@@ -11,7 +11,7 @@ PLATFORMS="darwin/386 darwin/amd64 freebsd/386 freebsd/amd64 freebsd/arm linux/3
 function go-alias {
 	GOOS=${1%/*}
 	GOARCH=${1#*/}
-	eval "function go-${GOOS}-${GOARCH} { ( GOOS=${GOOS} GOARCH=${GOARCH} go \$@ ) }"
+	eval "function go-${GOOS}-${GOARCH} { ( GOOS=${GOOS} GOARCH=${GOARCH} go \"\$@\" ) }"
 }
 
 function go-crosscompile-build {


### PR DESCRIPTION
Currently, the build fails for commands like `go-darwin-amd64 build -ldflags "-X main.Foo bar"` because the `-ldflags` parameter will be broken up into components when passed to the real go binary. This PR adds quoting to pass parameters through unmolested.
