### PR TITLE
if no src file given, use current dir name for executable name

### DIFF
--- a/crosscompile.bash
+++ b/crosscompile.bash
@@ -53,7 +53,9 @@ function go-build-all {
 	for PLATFORM in $PLATFORMS; do
 		GOOS=${PLATFORM%/*}
 		GOARCH=${PLATFORM#*/}
-		OUTPUT=`echo $@ | sed 's/\.go//'` 
+		SRCFILENAME=`echo $@ | sed 's/\.go//'` 
+		CURDIRNAME=${PWD##*/}
+		OUTPUT=${SRCFILENAME:-$CURDIRNAME} # if no src file given, use current dir name
 		CMD="go-${GOOS}-${GOARCH} build -o $OUTPUT-${GOOS}-${GOARCH} $@"
 		echo "$CMD"
 		$CMD || FAILURES="$FAILURES $PLATFORM"


### PR DESCRIPTION
when execute `go-build-all` without a src file, executables without a prefix are generated.

this change use the current dir name as prefix, if no src file are given
