### PR TITLE
README.md should point to the updated blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-See http://dave.cheney.net/2012/09/08/an-introduction-to-cross-compilation-with-go
+See http://dave.cheney.net/2013/07/09/an-introduction-to-cross-compilation-with-go-1-1


### PR DESCRIPTION
The repo description had been updated earlier to reflect the newer blog entry but not the README.
